### PR TITLE
Same styling changes (#961) from docs applied for better readability 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,6 +21,19 @@
   --color-cta-background-blue: #6270a4;
   --ifm-heading-font-family: Apax, sans-serif;
   --ifm-font-family-base: Inter, sans-serif;
+  --ifm-heading-font-weight: 400;
+  --ifm-h2-font-size: 1.5rem;
+  /* text margins */
+  --ifm-heading-margin-top: 1rem;
+  --ifm-paragraph-margin-bottom: 2rem;
+  --ifm-leading: 2rem;
+  /* paddings */
+  --ifm-spacing-vertical: 2.2rem;
+  --ifm-spacing-horizontal: 2.2rem;
+  --ifm-alert-padding-vertical: 1rem;
+  --ifm-alert-padding-horizontal: 1.2rem;
+  --ifm-navbar-padding-vertical: calc(var(--ifm-spacing-vertical) * 0.2);
+  --ifm-navbar-padding-horizontal: calc(var(--ifm-spacing-horizontal) * 0.5);
 }
 
 html[data-theme='dark'] {
@@ -44,6 +57,31 @@ html[data-theme='dark'] {
 @counter-style codeblock-line {
   system: extends decimal;
   suffix: '';
+}
+
+.markdown h1:first-child {
+  --ifm-h1-font-size: 2.2rem;
+}
+
+.markdown > h2 {
+  --ifm-h2-font-size: 1.5rem;
+}
+
+.menu {
+  font-size: 0.95rem;
+}
+
+/* notification and warning boxes */
+.admonition_node_modules-\@docusaurus-theme-classic-lib-theme-Admonition-Layout-styles-module {
+  margin-bottom: 2em !important;
+}
+.admonition_node_modules-\@docusaurus-theme-classic-lib-theme-Admonition-Layout-styles-module p {
+  margin: 0 0 1rem;
+}
+
+/* main content window top padding */
+.padding-top--md {
+  padding-top: 2rem !important;
 }
 
 .header-github-link:hover {


### PR DESCRIPTION
Before:
<img width="1436" alt="image" src="https://github.com/lukso-network/website-support-center/assets/9093326/f76ca39f-9955-497d-b05c-335a926952de">

After:
<img width="1436" alt="image" src="https://github.com/lukso-network/website-support-center/assets/9093326/8c6952e9-289e-4e1f-88f4-30a1e2570987">
