### PR TITLE
fix: broken privacy page redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -151,10 +151,9 @@ export default {
           items: [
             { label: 'LUKSO', href: 'https://lukso.network/' },
             { label: 'Team', href: 'https://lukso.network/people' },
-            { label: 'Careers', href: 'https://jobs.lukso.network/jobs' },
             {
               label: 'Privacy Policy',
-              href: 'https://lukso.network/privacy',
+              href: 'https://lukso.network/legal/privacy-policy',
             },
           ],
         },


### PR DESCRIPTION
This PR updates the privacy page URL to resolve a redirect issue.